### PR TITLE
Add @pytest.hookimpl(tryfirst=True) to pytest_load_initial_conftests …

### DIFF
--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -2,6 +2,8 @@
 
 from dotenv import load_dotenv
 
+import pytest
+
 
 def pytest_addoption(parser):
     parser.addini("env_files",
@@ -10,6 +12,7 @@ def pytest_addoption(parser):
                   default=[])
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(args, early_config, parser):
     for file in early_config.getini("env_files"):
         load_dotenv(file)


### PR DESCRIPTION
…in order to set environment variables before django settings are loaded