### PR TITLE
environment file paths now found using find_dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ You can list as many files as necessary:
 ```
 [pytest]
 env_files =
-    ./.env
-    ./.test.env
-    ./.deploy.env
+    .env
+    .test.env
+    .deploy.env
 ```
 
 The files will be loaded and added to the `os.environ` dict object before
-any tests are run.
+any tests are run. If the files are not found on the working directory, it will search for the files in the ancestor directory and upwards. 
 
 By default the plugin will not overwrite any variables already defined in the
 process' environment. If you want that behavior, you have to use the
@@ -35,7 +35,7 @@ process' environment. If you want that behavior, you have to use the
 [pytest]
 env_override_existing_values = 1
 env_files =
-    ./.env
-    ./.test.env
-    ./.deploy.env
+    .env
+    .test.env
+    .deploy.env
 ```

--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 import pytest
 
@@ -20,4 +20,4 @@ def pytest_addoption(parser):
 def pytest_load_initial_conftests(args, early_config, parser):
     _override = early_config.getini("env_override_existing_values")
     for filename in early_config.getini("env_files"):
-        load_dotenv(filename, override=_override)
+        load_dotenv(find_dotenv(filename), override=_override)


### PR DESCRIPTION
While the .env files path are relative to pytest.ini files the working directory is unchanged even if the pytest.ini file is not in the working directory but in an ancestor directory. This small fix makes sure the .env files are searched for in the same way pytest.ini is searched for by using the find_dotenv function.
This should maintain coherence even when starting tests in a submodule or specific file. 