### PR TITLE
Adds a default value of .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ pip install pytest-dotenv
 
 ## Basic Usage
 
-If all you want is to load environment variables from a `.env` file then installing the plugin is all that is needed. `python-dotenv` will automatically detect your `.env` file and load it. By default, the plugin wont override any existing system variables. 
+If all you want is to load environment variables from a `.env` file then installing the plugin is all that is needed. `python-dotenv` will automatically detect your `.env` file and load it. By default, the plugin won't override any existing system variables. 
 
 
 ## Non-default configuration

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # pytest-dotenv
 
-This little plugin uses `python-dotenv` to load any environment variables
-defined in any `pytest` config files, such as `pytest.ini`, `tox.ini` and so on.
+This little plugin uses `python-dotenv` to load any environment variables from a `.env` file. Extra configuration can be defined in any `pytest` config files, such as `pytest.ini`, `tox.ini` and so on.
 
 ## Installation
 
@@ -11,7 +10,14 @@ Install the plugin with `pip`:
 $ pip install pytest-dotenv
 ```
 
-## Usage
+## Basic Usage
+
+If all you want is to load environment variables from a `.env` file then installing the plugin is all that is needed. `python-dotenv` will automatically detect your `.env` file and load it. By default, the plugin wont override any existing system variables. 
+
+
+## Non-default configuration
+
+### Custom Environment Variable Files
 
 Add a new section to a config file named `env_vars`.
 You can list as many files as necessary:
@@ -26,6 +32,8 @@ env_files =
 
 The files will be loaded and added to the `os.environ` dict object before
 any tests are run. If the files are not found on the working directory, it will search for the files in the ancestor directory and upwards. 
+
+### Overriding Existing Values
 
 By default the plugin will not overwrite any variables already defined in the
 process' environment. If you want that behavior, you have to use the

--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
     parser.addini("env_files",
                   type="linelist",
                   help="a line separated list of env files to parse",
-                  default=[])
+                  default=['.env'])
     parser.addini("env_override_existing_values",
                   type="bool",
                   help="override the existing environment variables",


### PR DESCRIPTION
As per #3 unless otherwise defined in a pytest ini file the default .env should be used.