### PR TITLE
Allow to specify the path to a file via the command line

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include LICENSE
 include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -14,10 +14,18 @@ def pytest_addoption(parser):
                   type="bool",
                   help="override the existing environment variables",
                   default=False)
+    parser.addoption("--envfile",
+                    dest="envfile",
+                    default="foo",
+                    type=str,
+                    help="Overwrite any environment variable specified in this file. This argument ignores the .ini settings.")
 
 
-@pytest.hookimpl(tryfirst=True)
-def pytest_load_initial_conftests(args, early_config, parser):
-    _override = early_config.getini("env_override_existing_values")
-    for filename in early_config.getini("env_files"):
+def pytest_sessionstart(session):
+    config = session.config
+    _override = config.getini("env_override_existing_values")
+    for filename in config.getini("env_files"):
         load_dotenv(find_dotenv(filename, usecwd=True), override=_override)
+
+    if config.getoption("envfile", default=None) is not None:
+      load_dotenv(dotenv_path=config.getoption("envfile"), override=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = 'pytester'

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+def test_ini_file(testdir):
+    with mock.patch.dict('os.environ', clear=True):
+        testdir.makeini("""
+            [pytest]
+            env_files =
+                myenv.txt
+        """)
+
+        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+
+        # create a temporary pytest test module
+        testdir.makepyfile("""
+            import os
+
+            def test_env_foo():
+                assert os.environ.get('FOO') == 'BAR'
+
+            def test_env_spam():
+                assert os.environ.get('SPAM') == 'EGGS'
+        """)
+
+        # run pytest with the following cmd args
+        result = testdir.runpytest("-v")
+
+        # fnmatch_lines does an assertion internally
+        result.stdout.fnmatch_lines([
+            '*::test_env_foo PASSED*',
+            '*::test_env_spam PASSED*'
+        ])
+
+        # make sure that that we get a '0' exit code for the testsuite
+        assert result.ret == 0
+
+
+def test_ini_file_refuse_overwrite(testdir):
+    with mock.patch.dict('os.environ', clear=True):
+        testdir.makeini("""
+            [pytest]
+            env_override_existing_values = 0
+            env_files =
+                myenv.txt
+                overwrite.txt
+        """)
+
+        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+        testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
+        # create a temporary pytest test module
+        testdir.makepyfile("""
+            import os
+
+            def test_env_foo():
+                assert os.environ.get('FOO') == 'BAR'
+
+            def test_env_spam():
+                assert os.environ.get('SPAM') == 'EGGS'
+        """)
+
+        # run pytest with the following cmd args
+        result = testdir.runpytest("-v")
+
+        # fnmatch_lines does an assertion internally
+        result.stdout.fnmatch_lines([
+            '*::test_env_foo PASSED*',
+            '*::test_env_spam PASSED*'
+        ])
+
+        # make sure that that we get a '0' exit code for the testsuite
+        assert result.ret == 0
+
+
+def test_ini_file_allow_overwrite(testdir):
+    with mock.patch.dict('os.environ', clear=True):
+        testdir.makeini("""
+            [pytest]
+            env_override_existing_values = 1
+            env_files =
+                myenv.txt
+                overwrite.txt
+        """)
+
+        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+        testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
+        # create a temporary pytest test module
+        testdir.makepyfile("""
+            import os
+
+            def test_env_foo():
+                assert os.environ.get('FOO') == 'EGGS'
+
+            def test_env_spam():
+                assert os.environ.get('SPAM') == 'BAR'
+        """)
+
+        # run pytest with the following cmd args
+        result = testdir.runpytest("-v")
+
+        # fnmatch_lines does an assertion internally
+        result.stdout.fnmatch_lines([
+            '*::test_env_foo PASSED*',
+            '*::test_env_spam PASSED*'
+        ])
+
+        # make sure that that we get a '0' exit code for the testsuite
+        assert result.ret == 0
+
+
+def test_file_argument_force_overwrite(testdir):
+    with mock.patch.dict('os.environ', clear=True):
+        testdir.makeini("""
+            [pytest]
+            env_files =
+                myenv.txt
+        """)
+
+        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+        tmp_env_file = testdir.maketxtfile(tmpenv="FOO=BAZ\nBAR=SPAM")
+        # create a temporary pytest test module
+        testdir.makepyfile("""
+            import os
+
+            def test_env_foo():
+                assert os.environ.get('FOO') == 'BAZ'
+
+            def test_env_spam():
+                assert os.environ.get('SPAM') == 'EGGS'
+
+            def test_env_bar():
+                assert os.environ.get('BAR') == 'SPAM'
+        """)
+
+        # run pytest with the following cmd args
+        result = testdir.runpytest("-v", "--envfile", str(tmp_env_file))
+
+        # fnmatch_lines does an assertion internally
+        result.stdout.fnmatch_lines([
+            '*::test_env_foo PASSED*',
+            '*::test_env_spam PASSED*',
+            '*::test_env_bar PASSED*'
+        ])
+
+        # make sure that that we get a '0' exit code for the testsuite
+        assert result.ret == 0


### PR DESCRIPTION
This PR will add the option to specify a `.env` file (or similar) via the newly introduced command line option `--envfile`.

When this option is present, it will load the file and set all declared environment variables and ignores the setting `env_override_existing_values` specified in the `pytest.ini` file.

Futhermore the hook has been moved to `sessionstart` and tests have been added.