### PR TITLE
Set env before starting test session

### DIFF
--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -21,11 +21,14 @@ def pytest_addoption(parser):
                     help="Overwrite any environment variable specified in this file. This argument ignores the .ini settings.")
 
 
-def pytest_sessionstart(session):
-    config = session.config
-    _override = config.getini("env_override_existing_values")
-    for filename in config.getini("env_files"):
+@pytest.hookimpl(tryfirst=True)
+def pytest_load_initial_conftests(args, early_config, parser):
+    _override = early_config.getini("env_override_existing_values")
+    for filename in early_config.getini("env_files"):
         load_dotenv(find_dotenv(filename, usecwd=True), override=_override)
 
+
+def pytest_sessionstart(session):
+    config = session.config
     if config.getoption("envfile", default=None) is not None:
-      load_dotenv(dotenv_path=config.getoption("envfile"), override=True)
+        load_dotenv(dotenv_path=config.getoption("envfile"), override=True)

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
 
+
 def test_ini_file(testdir):
     with mock.patch.dict('os.environ', clear=True):
         testdir.makeini("""

--- a/tests/test_dotenv.py
+++ b/tests/test_dotenv.py
@@ -1,146 +1,154 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
 
+import pytest
 
+
+@pytest.fixture
+def mock_os_environ():
+    with mock.patch.dict("os.environ", clear=True) as m:
+        yield m
+
+
+@pytest.mark.usefixtures("mock_os_environ")
 def test_ini_file(testdir):
-    with mock.patch.dict('os.environ', clear=True):
-        testdir.makeini("""
-            [pytest]
-            env_files =
-                myenv.txt
-        """)
+    testdir.makeini("""
+        [pytest]
+        env_files =
+            myenv.txt
+    """)
 
-        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+    testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
 
-        # create a temporary pytest test module
-        testdir.makepyfile("""
-            import os
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        import os
 
-            def test_env_foo():
-                assert os.environ.get('FOO') == 'BAR'
+        def test_env_foo():
+            assert os.environ.get('FOO') == 'BAR'
 
-            def test_env_spam():
-                assert os.environ.get('SPAM') == 'EGGS'
-        """)
+        def test_env_spam():
+            assert os.environ.get('SPAM') == 'EGGS'
+    """)
 
-        # run pytest with the following cmd args
-        result = testdir.runpytest("-v")
+    # run pytest with the following cmd args
+    result = testdir.runpytest("-v")
 
-        # fnmatch_lines does an assertion internally
-        result.stdout.fnmatch_lines([
-            '*::test_env_foo PASSED*',
-            '*::test_env_spam PASSED*'
-        ])
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_env_foo PASSED*',
+        '*::test_env_spam PASSED*'
+    ])
 
-        # make sure that that we get a '0' exit code for the testsuite
-        assert result.ret == 0
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
 
 
+@pytest.mark.usefixtures("mock_os_environ")
 def test_ini_file_refuse_overwrite(testdir):
-    with mock.patch.dict('os.environ', clear=True):
-        testdir.makeini("""
-            [pytest]
-            env_override_existing_values = 0
-            env_files =
-                myenv.txt
-                overwrite.txt
-        """)
+    testdir.makeini("""
+        [pytest]
+        env_override_existing_values = 0
+        env_files =
+            myenv.txt
+            overwrite.txt
+    """)
 
-        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
-        testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
-        # create a temporary pytest test module
-        testdir.makepyfile("""
-            import os
+    testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+    testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        import os
 
-            def test_env_foo():
-                assert os.environ.get('FOO') == 'BAR'
+        def test_env_foo():
+            assert os.environ.get('FOO') == 'BAR'
 
-            def test_env_spam():
-                assert os.environ.get('SPAM') == 'EGGS'
-        """)
+        def test_env_spam():
+            assert os.environ.get('SPAM') == 'EGGS'
+    """)
 
-        # run pytest with the following cmd args
-        result = testdir.runpytest("-v")
+    # run pytest with the following cmd args
+    result = testdir.runpytest("-v")
 
-        # fnmatch_lines does an assertion internally
-        result.stdout.fnmatch_lines([
-            '*::test_env_foo PASSED*',
-            '*::test_env_spam PASSED*'
-        ])
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_env_foo PASSED*',
+        '*::test_env_spam PASSED*'
+    ])
 
-        # make sure that that we get a '0' exit code for the testsuite
-        assert result.ret == 0
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
 
 
+@pytest.mark.usefixtures("mock_os_environ")
 def test_ini_file_allow_overwrite(testdir):
-    with mock.patch.dict('os.environ', clear=True):
-        testdir.makeini("""
-            [pytest]
-            env_override_existing_values = 1
-            env_files =
-                myenv.txt
-                overwrite.txt
-        """)
+    testdir.makeini("""
+        [pytest]
+        env_override_existing_values = 1
+        env_files =
+            myenv.txt
+            overwrite.txt
+    """)
 
-        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
-        testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
-        # create a temporary pytest test module
-        testdir.makepyfile("""
-            import os
+    testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+    testdir.maketxtfile(overwrite="FOO=EGGS\nSPAM=BAR")
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        import os
 
-            def test_env_foo():
-                assert os.environ.get('FOO') == 'EGGS'
+        def test_env_foo():
+            assert os.environ.get('FOO') == 'EGGS'
 
-            def test_env_spam():
-                assert os.environ.get('SPAM') == 'BAR'
-        """)
+        def test_env_spam():
+            assert os.environ.get('SPAM') == 'BAR'
+    """)
 
-        # run pytest with the following cmd args
-        result = testdir.runpytest("-v")
+    # run pytest with the following cmd args
+    result = testdir.runpytest("-v")
 
-        # fnmatch_lines does an assertion internally
-        result.stdout.fnmatch_lines([
-            '*::test_env_foo PASSED*',
-            '*::test_env_spam PASSED*'
-        ])
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_env_foo PASSED*',
+        '*::test_env_spam PASSED*'
+    ])
 
-        # make sure that that we get a '0' exit code for the testsuite
-        assert result.ret == 0
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
 
 
+@pytest.mark.usefixtures("mock_os_environ")
 def test_file_argument_force_overwrite(testdir):
-    with mock.patch.dict('os.environ', clear=True):
-        testdir.makeini("""
-            [pytest]
-            env_files =
-                myenv.txt
-        """)
+    testdir.makeini("""
+        [pytest]
+        env_files =
+            myenv.txt
+    """)
 
-        testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
-        tmp_env_file = testdir.maketxtfile(tmpenv="FOO=BAZ\nBAR=SPAM")
-        # create a temporary pytest test module
-        testdir.makepyfile("""
-            import os
+    testdir.maketxtfile(myenv="FOO=BAR\nSPAM=EGGS")
+    tmp_env_file = testdir.maketxtfile(tmpenv="FOO=BAZ\nBAR=SPAM")
+    # create a temporary pytest test module
+    testdir.makepyfile("""
+        import os
 
-            def test_env_foo():
-                assert os.environ.get('FOO') == 'BAZ'
+        def test_env_foo():
+            assert os.environ.get('FOO') == 'BAZ'
 
-            def test_env_spam():
-                assert os.environ.get('SPAM') == 'EGGS'
+        def test_env_spam():
+            assert os.environ.get('SPAM') == 'EGGS'
 
-            def test_env_bar():
-                assert os.environ.get('BAR') == 'SPAM'
-        """)
+        def test_env_bar():
+            assert os.environ.get('BAR') == 'SPAM'
+    """)
 
-        # run pytest with the following cmd args
-        result = testdir.runpytest("-v", "--envfile", str(tmp_env_file))
+    # run pytest with the following cmd args
+    result = testdir.runpytest("-v", "--envfile", str(tmp_env_file))
 
-        # fnmatch_lines does an assertion internally
-        result.stdout.fnmatch_lines([
-            '*::test_env_foo PASSED*',
-            '*::test_env_spam PASSED*',
-            '*::test_env_bar PASSED*'
-        ])
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*::test_env_foo PASSED*',
+        '*::test_env_spam PASSED*',
+        '*::test_env_bar PASSED*'
+    ])
 
-        # make sure that that we get a '0' exit code for the testsuite
-        assert result.ret == 0
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0


### PR DESCRIPTION
This PR brings back the functionality from version 0.4.0, where the env variables were set before starting the pytest session. This behaviour was broken in version 0.5.0 with the below commit:
https://github.com/quiqua/pytest-dotenv/commit/b517a524b5824b0026617b8e182d226f93c906d0