### PR TITLE
add stderr message if env file not found

### DIFF
--- a/pytest_dotenv/plugin.py
+++ b/pytest_dotenv/plugin.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+import sys
 
 from dotenv import load_dotenv, find_dotenv
 
@@ -25,10 +27,18 @@ def pytest_addoption(parser):
 def pytest_load_initial_conftests(args, early_config, parser):
     _override = early_config.getini("env_override_existing_values")
     for filename in early_config.getini("env_files"):
+        _check_exists(filename)
         load_dotenv(find_dotenv(filename, usecwd=True), override=_override)
 
 
 def pytest_sessionstart(session):
     config = session.config
-    if config.getoption("envfile", default=None) is not None:
-        load_dotenv(dotenv_path=config.getoption("envfile"), override=True)
+    env_file = config.getoption("envfile", default=None)
+    if env_file is not None:
+        _check_exists(env_file)
+        load_dotenv(dotenv_path=env_file, override=True)
+
+
+def _check_exists(filename):
+    if not os.path.exists(filename):
+        sys.stderr.write("Env file not found: %s\n" % filename)


### PR DESCRIPTION
This PR should add a simple `stderr` message if the env file is not actually found.